### PR TITLE
Upgrade Prelert Kibana swimlane visualization plugin to version 5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ response times:
 Different releases of the plugin are available to work with either Kibana 4 or Kibana 5.
 
 The distribution for Kibana 4 has been tested with Kibana versions 4.3, 4.4, 4.5 and 4.6, and the Kibana 5
-build with versions 5.0.0, 5.0.1 and 5.0.2.
+build with versions 5.0.0, 5.0.1, 5.0.2 and 5.1.2.
 
 ## Installation
 
@@ -54,6 +54,12 @@ bin/kibana-plugin install https://github.com/prelert/kibana-swimlane-vis/release
 
 ```
 bin/kibana-plugin install https://github.com/prelert/kibana-swimlane-vis/releases/download/v5.0.2/prelert_swimlane_vis-5.0.2.zip
+```
+
+### Kibana 5.1.2:
+
+```
+bin/kibana-plugin install https://github.com/prelert/kibana-swimlane-vis/releases/download/v5.0.2/prelert_swimlane_vis-5.1.2.zip
 ```
 
 ## Uninstall

--- a/package.json
+++ b/package.json
@@ -1,6 +1,26 @@
 {
   "name": "prelert_swimlane_vis",
-  "version": "5.0.2",
+  "version": "5.1.2",
   "description": "Prelert swimlane visualization plugin",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "kibana": {
+    "version": "5.1.2"
+  },
+  "scripts": {
+    "lint": "eslint",
+    "start": "plugin-helpers start",
+    "test:server": "plugin-helpers test:server",
+    "test:browser": "plugin-helpers test:browser",
+    "build": "plugin-helpers build",
+    "postinstall": "plugin-helpers postinstall"
+  },
+  "devDependencies": {
+    "@elastic/eslint-config-kibana": "0.0.2",
+    "@elastic/plugin-helpers": "^6.0.0",
+    "babel-eslint": "4.1.8",
+    "chai": "^3.5.0",
+    "eslint": "1.10.3",
+    "eslint-plugin-mocha": "1.1.0"
+  }
 }

--- a/public/prelert_swimlane_vis_controller.js
+++ b/public/prelert_swimlane_vis_controller.js
@@ -132,9 +132,9 @@ module.controller('PrelertSwimlaneVisController', function ($scope, courier) {
       scopeInterval = $scope.vis.params.interval.customInterval;
     }
 
-    let setToInterval = _.findWhere($scope.vis.type.params.intervalOptions, {val: aggInterval});
+    let setToInterval = _.find($scope.vis.type.params.intervalOptions, {val: aggInterval});
     if (!setToInterval) {
-      setToInterval = _.findWhere($scope.vis.type.params.intervalOptions, {customInterval: aggInterval});
+      setToInterval = _.find($scope.vis.type.params.intervalOptions, {customInterval: aggInterval});
     }
     if (!setToInterval) {
       // e.g. if running inside the Kibana Visualization tab will need to add an extra option in.
@@ -208,7 +208,7 @@ module.controller('PrelertSwimlaneVisController', function ($scope, courier) {
 
   }
 
-  $scope.prelertLogoSrc = chrome.getBasePath() + '/plugins/prelert_swimlane_vis/prelert_logo_24.png';
+  $scope.prelertLogoSrc = require('plugins/prelert_swimlane_vis/prelert_logo_24.png');
 
 })
 .directive('prlSwimlaneVis', function ($compile, timefilter) {
@@ -451,7 +451,7 @@ module.controller('PrelertSwimlaneVisController', function ($scope, courier) {
       // Reverse so that the order is a-z from the top.
       keys = keys.reverse();
 
-      return _.object(keys, _.map(keys, function (key) {
+      return _.zipObject(keys, _.map(keys, function (key) {
         return list[key];
       }));
     }


### PR DESCRIPTION
- Edits to package.json and README for 5.1.2 & 5.2.2 version
- update lodash methods
- bugfix prelert logo display

You can already test this version (5.1.2) before releasing by doing this:
[prelert_swimlane_vis-5.1.2.zip](https://github.com/prelert/kibana-swimlane-vis/files/888388/prelert_swimlane_vis-5.1.2.zip)
$ curl -Ls --output /tmp/prelert_swimlane_vis-5.1.2.zip "https://github.com/prelert/kibana-swimlane-vis/files/888388/prelert_swimlane_vis-5.1.2.zip"
./kibana-plugin install file:///tmp/prelert_swimlane_vis-5.1.2.zip

You can already test this version (5.2.2) before releasing by doing this:
[prelert_swimlane_vis-5.2.2.zip](https://github.com/prelert/kibana-swimlane-vis/files/888389/prelert_swimlane_vis-5.2.2.zip)
$ curl -Ls --output /tmp/prelert_swimlane_vis-5.2.2.zip "https://github.com/prelert/kibana-swimlane-vis/files/888389/prelert_swimlane_vis-5.2.2.zip"
./kibana-plugin install file:///tmp/prelert_swimlane_vis-5.2.2.zip





